### PR TITLE
feat: Implement background service to find nearby stations

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -100,5 +100,9 @@ dependencies {
     // Coroutines testing
     testImplementation("org.mockito.kotlin:mockito-kotlin:5.+")
     testImplementation("androidx.arch.core:core-testing:2.2.0")
-    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.8.1")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.10.2")
+
+    // WorkManager
+    implementation(libs.androidx.work.runtime.ktx)
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
+
     <application
         android:name=".Application"
         android:allowBackup="true"
@@ -32,6 +33,12 @@
         <meta-data
             android:name="com.google.android.geo.API_KEY"
             android:value="AIzaSyD47IRfTc5mSGqV3AA6blKwv9Vs5O3wU8Y" />
+
+        <service
+            android:name=".utils.service.StationCheckService"
+            android:enabled="true"
+            android:exported="false"
+            android:foregroundServiceType="location" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/educacionit/biciya/home/contracts/request/RequestView.kt
+++ b/app/src/main/java/com/educacionit/biciya/home/contracts/request/RequestView.kt
@@ -13,6 +13,7 @@ interface RequestView {
     fun onRequestError(msg: String)
     fun onInactiveRequestsLoaded(requests: List<RequestEntity>)
     fun onActiveRequestLoaded(request: RequestEntity)
+    fun setNoRequestsVisibility(isVisible : Boolean)
     fun setNoActiveRequestsVisibility(isVisible: Boolean)
     fun setInactivesRequestsVisibility(isVisible: Boolean)
 }

--- a/app/src/main/java/com/educacionit/biciya/home/contracts/request/presenter/RequestPresenterImpl.kt
+++ b/app/src/main/java/com/educacionit/biciya/home/contracts/request/presenter/RequestPresenterImpl.kt
@@ -1,13 +1,15 @@
 package com.educacionit.biciya.home.contracts.request.presenter
 
 import android.content.Context
+import android.content.Intent
+import android.os.Build
 import android.util.Log
-import android.widget.Toast
 import com.educacionit.biciya.R
 import com.educacionit.biciya.data.RequestRepository
 import com.educacionit.biciya.data.database.RequestEntity
 import com.educacionit.biciya.home.contracts.request.RequestView
 import com.educacionit.biciya.utils.notification.NotificationHelper
+import com.educacionit.biciya.utils.service.StationCheckService
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -27,7 +29,6 @@ class RequestPresenterImpl(
             return
         }
 
-
         try {
             withContext(presenterScope.coroutineContext) {
                 val activeRequest = repository.getActiveRequest()
@@ -43,6 +44,13 @@ class RequestPresenterImpl(
                     active = true
                 )
                 repository.insertRequest(newRequest)
+            }
+            Log.e("saveRequest" , "saveRequest - pre-startStationCheckWorker")
+            val intent = Intent(context, StationCheckService::class.java)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                context.startForegroundService(intent)
+            } else {
+                context.startService(intent)
             }
 
             view.onRequestSaved()
@@ -64,6 +72,7 @@ class RequestPresenterImpl(
                 view.setInactivesRequestsVisibility(true)
             } else {
                 view.setInactivesRequestsVisibility(false)
+                view.setNoRequestsVisibility(false)
                 view.onInactiveRequestsLoaded(requests)
             }
         } catch (e: Exception) {
@@ -83,6 +92,7 @@ class RequestPresenterImpl(
             activeRequests?.let {
                 Log.d("getActiveRequest()", "Hay una solicitud activa")
                 view.setNoActiveRequestsVisibility(false)
+                view.setNoRequestsVisibility(false)
                 view.onActiveRequestLoaded(activeRequests)
             } ?: run {
                 Log.d("getActiveRequest()", "No hay solicitud activa")

--- a/app/src/main/java/com/educacionit/biciya/home/model/LocationProvider.kt
+++ b/app/src/main/java/com/educacionit/biciya/home/model/LocationProvider.kt
@@ -45,7 +45,8 @@ class LocationProvider(private val weakContext: WeakReference<Context>) : HomeMo
                 locationCallback = object : LocationCallback() {
                     override fun onLocationResult(locationResult: LocationResult) {
                         locationResult.lastLocation?.let {
-                            onaLocationUpdate(LatLng(it.latitude, it.longitude))
+                            val latLong = LatLng(it.latitude, it.longitude)
+                            onaLocationUpdate(latLong)
                         }
                     }
                 }

--- a/app/src/main/java/com/educacionit/biciya/home/view/RequestsFragment.kt
+++ b/app/src/main/java/com/educacionit/biciya/home/view/RequestsFragment.kt
@@ -45,6 +45,7 @@ class RequestsFragment : Fragment(), RequestView {
     private lateinit var tvRange: TextView
     private lateinit var tvBikeCount: TextView
     private lateinit var frameNoData: FrameLayout
+    private lateinit var frameNoActiveRequest : FrameLayout
     private lateinit var frameNoInactiveData: FrameLayout
 
 
@@ -83,6 +84,7 @@ class RequestsFragment : Fragment(), RequestView {
         tvBikeCount = view.findViewById(R.id.tvBikeCount)
         frameNoData = view.findViewById(R.id.frameNoData)
         frameNoInactiveData = view.findViewById(R.id.frameNoInactiveData)
+        frameNoActiveRequest = view.findViewById(R.id.frameNoActiveRequest)
 
         initRecyclerAdapter()
     }
@@ -122,14 +124,19 @@ class RequestsFragment : Fragment(), RequestView {
         tvBikeCount.text = getString(R.string.bikes_requests, request.bikesRequested.toString())
     }
 
-    override fun setNoActiveRequestsVisibility(isVisible: Boolean) {
-        Log.e("setNoActiveRequestsVisibility", "frameNoData isvisible = $isVisible")
+    override fun setNoRequestsVisibility(isVisible: Boolean) {
+        Log.e("setNoRequestsVisibility", "frameNoData isvisible = $isVisible")
         frameNoData.isVisible = isVisible
+    }
+
+    override fun setNoActiveRequestsVisibility(isVisible: Boolean) {
+        Log.e("setNoActiveRequestsVisibility", "frameNoActiveRequest isvisible = $isVisible")
+        frameNoActiveRequest.isVisible = isVisible
     }
 
     override fun setInactivesRequestsVisibility(isVisible: Boolean) {
         Log.e(
-            "setNoActiveRequestsVisibility",
+            "setInactivesRequestsVisibility",
             "frameNoInactiveData isvisible = $isVisible"
         )
         frameNoInactiveData.isVisible = isVisible

--- a/app/src/main/java/com/educacionit/biciya/utils/Constants.kt
+++ b/app/src/main/java/com/educacionit/biciya/utils/Constants.kt
@@ -3,6 +3,8 @@ package com.educacionit.biciya.utils
 object Constants {
     const val STATE_INSTANCE = "STATE_INSTANCE"
 
+    //String
+    const val DATE_FORMAT = "dd/MM/yyyy HH:mm"
 
     //Permissions
     const val REQUEST_LOCATION_SETTINGS = 1000
@@ -16,4 +18,5 @@ object Constants {
 
     //Api
     const val BASE_URL = "https://apitransporte.buenosaires.gob.ar/ecobici/gbfs/"
+
 }

--- a/app/src/main/java/com/educacionit/biciya/utils/notification/NotificationHelper.kt
+++ b/app/src/main/java/com/educacionit/biciya/utils/notification/NotificationHelper.kt
@@ -9,12 +9,15 @@ import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Build
+import androidx.annotation.RequiresPermission
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import androidx.core.content.ContextCompat
 import com.educacionit.biciya.R
 import com.educacionit.biciya.home.view.HomeActivity
+import com.educacionit.biciya.models.response.Station
 import com.educacionit.biciya.utils.Constants
+import okhttp3.internal.notify
 import kotlin.jvm.java
 
 object NotificationHelper {
@@ -51,5 +54,49 @@ object NotificationHelper {
 
         NotificationManagerCompat.from(context)
             .notify((System.currentTimeMillis() % Int.MAX_VALUE).toInt(), builder.build())
+    }
+
+    @RequiresPermission(Manifest.permission.POST_NOTIFICATIONS)
+    fun showStationNearbyNotification(context: Context, station: Station) {
+
+        val notification = NotificationCompat.Builder(context, Constants.CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_bike_notification)
+            .setContentTitle(context.getString(R.string.nerby_station))
+            .setContentText(context.getString(R.string.nerby_station_message, station.name))
+            .setPriority(NotificationCompat.PRIORITY_HIGH)
+            .setAutoCancel(true)
+            .build()
+
+        NotificationManagerCompat.from(context).notify((System.currentTimeMillis() % Int.MAX_VALUE).toInt(), notification)
+    }
+
+    @RequiresPermission(Manifest.permission.POST_NOTIFICATIONS)
+    fun showExpiredRequestNotification(context: Context) {
+        createNotificationChannel(context)
+
+        val notification = NotificationCompat.Builder(context, Constants.CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_bike_notification)
+            .setContentTitle(context.getString(R.string.app_name))
+            .setContentText(context.getString(R.string.expired_request))
+            .setPriority(NotificationCompat.PRIORITY_HIGH)
+            .setAutoCancel(true)
+            .build()
+
+        NotificationManagerCompat.from(context)
+            .notify((System.currentTimeMillis() % Int.MAX_VALUE).toInt(), notification)
+    }
+
+    fun createSimpleNotification(context: Context, message: String): android.app.Notification {
+        createNotificationChannel(context)
+
+        val builder = NotificationCompat.Builder(context, Constants.CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_bike_notification)
+            .setContentTitle(context.getString(R.string.app_name))
+            .setContentText(message)
+            .setPriority(NotificationCompat.PRIORITY_LOW)
+            .setOngoing(true)
+            .build()
+
+        return builder
     }
 }

--- a/app/src/main/java/com/educacionit/biciya/utils/popup/PopUpManager.kt
+++ b/app/src/main/java/com/educacionit/biciya/utils/popup/PopUpManager.kt
@@ -14,6 +14,7 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import com.educacionit.biciya.R
 import com.educacionit.biciya.home.contracts.request.presenter.RequestPresenter
+import com.educacionit.biciya.utils.Constants
 import com.google.android.material.slider.RangeSlider
 import kotlinx.coroutines.launch
 import java.text.SimpleDateFormat
@@ -28,7 +29,7 @@ class PopUpManager(
     companion object {
         val MINIMUM_BIKES_REQUEST = 1
         val MAXIMUM_BIKES_REQUEST = 20
-        val DATE_FORMAT = "dd/MM/yyyy HH:mm"
+        val DATE_FORMAT = Constants.DATE_FORMAT
         val DEFAULT_DISTANCE = 100
     }
 

--- a/app/src/main/java/com/educacionit/biciya/utils/service/StationCheckService.kt
+++ b/app/src/main/java/com/educacionit/biciya/utils/service/StationCheckService.kt
@@ -1,0 +1,159 @@
+package com.educacionit.biciya.utils.service
+
+import android.Manifest
+import android.annotation.SuppressLint
+import android.app.Service
+import android.content.Intent
+import android.os.Build
+import android.util.Log
+import androidx.annotation.RequiresPermission
+import com.educacionit.biciya.R
+import com.educacionit.biciya.data.database.AppDatabase
+import com.educacionit.biciya.data.database.RequestEntity
+import com.educacionit.biciya.models.response.Station
+import com.educacionit.biciya.network.ApiClient
+import com.educacionit.biciya.utils.Constants
+import com.educacionit.biciya.utils.notification.NotificationHelper
+import com.google.android.gms.location.LocationServices
+import com.google.android.gms.location.Priority
+import com.google.android.gms.maps.model.LatLng
+import kotlinx.coroutines.*
+import kotlinx.coroutines.tasks.await
+import kotlin.let
+import kotlin.math.*
+
+class StationCheckService : Service() {
+    private val coroutineScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+    private var isRunning = true
+    private val delayService = 30_000L
+
+    override fun onCreate() {
+        super.onCreate()
+        startForeground(
+            1,
+            NotificationHelper.createSimpleNotification(
+                this,
+                getString(R.string.searching_nearby_stations)
+            )
+        )
+
+        coroutineScope.launch {
+            while (isRunning) {
+                checkNearbyStations()
+                delay(delayService)
+            }
+        }
+    }
+
+    @SuppressLint("MissingPermission")
+    private suspend fun checkNearbyStations() {
+        try {
+            val fused = LocationServices.getFusedLocationProviderClient(this)
+            val location = fused.getCurrentLocation(
+                Priority.PRIORITY_HIGH_ACCURACY, null
+            ).await()
+
+            location?.let {
+                val userLatLng = LatLng(it.latitude, it.longitude)
+                val stations = getStationsByApi() ?: return
+                val activeRequest = getActiveRequest() ?: return
+
+                if (!validateDateOfRequest(activeRequest)) return
+
+                val nearby = stations.filter { station ->
+                    val distance = calculateDistance(userLatLng, LatLng(station.lat, station.lon))
+                    distance <= activeRequest.distanceRange
+                }
+
+                nearby.firstOrNull()?.let { station ->
+                    notifyNearbyStation(station)
+                    desactiveRequest()
+                    stopSelf()
+                    isRunning = false
+                    Log.e("StationCheckService", "Estación encontrada, servicio detenido")
+                }
+            }
+        } catch (e: Exception) {
+            Log.e("StationCheckService", "Error: ${e.message}", e)
+        }
+    }
+
+    override fun onDestroy() {
+        isRunning = false
+        coroutineScope.cancel()
+        stopForeground(true)
+        super.onDestroy()
+    }
+
+    override fun onBind(intent: Intent?) = null
+
+    private fun calculateDistance(start: LatLng, end: LatLng): Double {
+        /*
+        * Calculos matematicos de GPT. propenso a fallar
+         */
+        val R = 6371000.0
+        val dLat = Math.toRadians(end.latitude - start.latitude)
+        val dLon = Math.toRadians(end.longitude - start.longitude)
+        val a = sin(dLat / 2).pow(2) +
+                cos(Math.toRadians(start.latitude)) *
+                cos(Math.toRadians(end.latitude)) *
+                sin(dLon / 2).pow(2)
+        return 2 * R * atan2(sqrt(a), sqrt(1 - a))
+    }
+
+    private suspend fun getStationsByApi(): List<Station>? {
+        val response = ApiClient.ecobiciService.getStationInformation()
+        val stations = response.body()?.data?.stations
+        return stations
+    }
+
+    private suspend fun getActiveRequest(): RequestEntity? {
+        return AppDatabase.getInstance(this).requestDao().getActiveRequest()
+    }
+
+    private suspend fun desactiveRequest() {
+        AppDatabase.getInstance(this).requestDao().deactivateActiveRequest()
+    }
+
+    @RequiresPermission(Manifest.permission.POST_NOTIFICATIONS)
+    private fun notifyNearbyStation(station: Station) {
+        NotificationHelper.showStationNearbyNotification(this, station)
+    }
+
+    @RequiresPermission(Manifest.permission.POST_NOTIFICATIONS)
+    private fun notifyExpiredRequest() {
+        NotificationHelper.showExpiredRequestNotification(this)
+    }
+
+    private suspend fun validateDateOfRequest(activeRequest: RequestEntity): Boolean {
+        return try {
+            val expirationMillis = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                val formatter = java.time.format.DateTimeFormatter.ofPattern(Constants.DATE_FORMAT)
+                val expirationDateTime =
+                    java.time.LocalDateTime.parse(activeRequest.expirationDate, formatter)
+                val zoneId = java.time.ZoneId.systemDefault()
+                expirationDateTime.atZone(zoneId).toInstant().toEpochMilli()
+            } else {
+                val sdf =
+                    java.text.SimpleDateFormat(Constants.DATE_FORMAT, java.util.Locale.getDefault())
+                val date = sdf.parse(activeRequest.expirationDate)
+                date?.time ?: 0L
+            }
+
+            val isStillValid = System.currentTimeMillis() <= expirationMillis
+
+            if (!isStillValid) {
+                desactiveRequest()
+                notifyExpiredRequest()
+                stopSelf()
+                isRunning = false
+                Log.e("validateDateOfRequest", "Request vencido, servicio detenido")
+            }
+
+            isStillValid
+        } catch (e: Exception) {
+            Log.e("validateDateOfRequest", "Error al parsear fecha: ${e.message}")
+            false
+        }
+    }
+}

--- a/app/src/main/res/layout/fragment_requests.xml
+++ b/app/src/main/res/layout/fragment_requests.xml
@@ -74,6 +74,20 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/subtitle1" />
 
+        <FrameLayout
+            android:id="@+id/frameNoActiveRequest"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:visibility="visible"
+            app:layout_constraintBottom_toTopOf="@+id/subtitle2"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/subtitle1" >
+
+            <include layout="@layout/item_no_data"
+                android:visibility="visible"/>
+        </FrameLayout>
+
         <LinearLayout
             android:id="@+id/subtitle2"
             android:layout_width="0dp"

--- a/app/src/main/res/layout/item_no_data.xml
+++ b/app/src/main/res/layout/item_no_data.xml
@@ -23,12 +23,12 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center"
-                android:layout_marginBottom="-40dp"
+                android:layout_marginBottom="-20dp"
                 android:text="@string/no_requests_message" />
 
             <com.airbnb.lottie.LottieAnimationView
                 android:layout_width="wrap_content"
-                android:layout_height="200dp"
+                android:layout_height="100dp"
                 android:layout_gravity="center"
                 app:lottie_autoPlay="true"
                 app:lottie_loop="true"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -30,6 +30,10 @@
     <string name="no_expiration_date_message">Debe ingresar una fecha de expiración</string>
     <string name="no_notification_permission_message">No se pueden mostrar notificaciones sin permiso</string>
     <string name="no_requests_message">No tiene solicitudes realizadas</string>
+    <string name="nerby_station">Estación cercana</string>
+    <string name="nerby_station_message">La estación %1$s cumple con los requisitos solicitados e ingreso al radio de busqueda</string>
+    <string name="searching_nearby_stations">Buscando estaciones cercanas...</string>
+    <string name="expired_request">ha expirado el tiempo de busqueda</string>
 
 
 </resources>


### PR DESCRIPTION
This commit introduces a foreground service to periodically check for nearby bike stations that match an active user request. When a suitable station is found, a notification is shown, and the service stops.

Specific changes:
- Creates `StationCheckService`, a foreground service that runs every 30 seconds to find stations within the user-defined range.
- Implements logic to check the active request's expiration date and automatically deactivate it if the time has passed.
- Adds `NotificationHelper` functions to show notifications for nearby stations and expired requests.
- Starts the `StationCheckService` after a new request is successfully saved.
- Refactors the UI in `RequestsFragment` to correctly display "no data" states for active and inactive requests.
- Adds new string resources for notifications and service messages.
- Updates dependencies for `kotlinx-coroutines-play-services`.